### PR TITLE
Add LegacyDoc AI to community shares

### DIFF
--- a/share/README.md
+++ b/share/README.md
@@ -19,3 +19,13 @@
 * You can also create your own custom effects .
 
 <image src="https://user-images.githubusercontent.com/130225999/231623769-d86a09e8-1611-4b38-a6ba-c87aea9bd13f.png" width="60%" />
+
+### LegacyDoc AI
+
+* LegacyDoc AI is a VS Code extension that generates AI code audit reports, Mermaid architecture maps, JSDoc, Markdown docs, and AI-ready context packs from your codebase.
+
+* It is useful for inherited projects, AI-generated MVPs, and vibe-coded prototypes that need documentation and cleanup context before refactor or handoff.
+
+* Product page: <https://www.romanticode.com/legacydoc-ai/>
+
+* VS Code Marketplace: <https://marketplace.visualstudio.com/items?itemName=ruilegendoc.legacy-doc-ai>


### PR DESCRIPTION
Adds LegacyDoc AI to the community sharing area in `share/README.md`.

LegacyDoc AI is a VS Code extension for generating AI code audit reports, Mermaid architecture maps, JSDoc, Markdown docs, and AI-ready context packs from a codebase.

Verification:
- Only `share/README.md` changed
- Product page returns HTTP 200
- VS Code Marketplace page returns HTTP 200

Thanks for maintaining this VS Code extensions list.